### PR TITLE
Restrict usage of useLazyQuery and useMutation in favor of clearer code

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,26 @@ module.exports = {
       },
     ],
 
+    'no-restricted-syntax': [
+      'warn',
+      'WithStatement',
+      {
+        selector:
+          "CallExpression[callee.name='setTimeout'][arguments.length!=2]",
+        message: 'setTimeout must always be invoked with two arguments.',
+      },
+      {
+        selector: "CallExpression[callee.name='useLazyQuery']",
+        message:
+          'Prefer apolloClient.query in handlers over useLazyQuery hooks. The useLazyQuery introduce misdirection that makes code hard to follow, especially when the behavior gets more complicated. Error handling also improves using apolloClient.query.',
+      },
+      {
+        selector: "CallExpression[callee.name='useMutation']",
+        message:
+          'Prefer apolloClient.mutate in handlers over useMutation hooks. The useMutation introduce misdirection that makes code hard to follow, especially when the behavior gets more complicated. Error handling also improves using apolloClient.mutate.',
+      },
+    ],
+
     // TODO: Rule to encourage foreach/map/reduce over for
 
     // endregion


### PR DESCRIPTION
We avoid the useMutation hooks, even though this seems to be normal to use according to the Apollo docs. Our experience is that it's a lot harder to follow behavior as code gets more complicated. Basic setup:

```
const { mutate, isLoading, data, error } = useMutation(x)
const handleClick = () => { mutate(y) }
useEffect(() => { 
  if (data.someResult.succeeded) {
    push(newRoute);
  } 
}, [data, push])
useEffect(() => {
  if (error) {
    setError(error);
  }
}, [error])
```

vs

```
const apolloClient = useApolloClient();
const handleClick = async () => {
  try {
    if (await doSomething(apolloClient, y)) {
      push(newRoute);
    }
  } catch {
    setError(error)
  }
}
```

These examples aren't that bad regarding complexity, but as behavior grows it gets increasingly harder with the useMutation hook to follow due to having to go from mutate to hook to useEffect to follow the order of calls, while that's procedural classic JS with the apolloClient.mutate function.