### PR TITLE
Update no-unsafe-negation: enable enforceForOrderingRelations

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,10 @@ module.exports = {
       },
     ],
 
+    // if (!a > b) will convert a into a boolean since ! has precendence over >
+    // Note: @typescript-eslint disables this for TS files since TS also checks for this.
+    'no-unsafe-negation': ['error', { enforceForOrderingRelations: true }],
+
     // TODO: Rule to encourage foreach/map/reduce over for
 
     // endregion


### PR DESCRIPTION
The default is false, which allows some errors to fallthrough. Note that since @typescript-eslint disables this for .ts(x) files, this rule should only apply to JS files.

Based on a DeepCode suggestion:
![image](https://user-images.githubusercontent.com/4565223/99449970-62e81000-2920-11eb-870c-621aee24c141.png)
