### PR TITLE
Only enable auto-fixable code-style rules in CI/CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,6 @@ That's it! You can override the settings by editing the `.eslintrc.json` file. L
 
 These options can be enabled/disabled using env variables.
 
-`PRETTIER` Enable or disable prettier rules in eslint
+`CODE_STYLE` Enable or disable code style rules in eslint. These rules are
+automatically fixable, so this can be run in a precommit hook with `--fix`.
 `EMICO_COMPONENT_LIBRARY` Enable or disable Emico internal component library rules


### PR DESCRIPTION
This way code style rules do not slow development down, while the outputed code still has a consistent code style.

Also enables an import/order rule to group @emico imports separate from other library imports.

Also changed a couple of rule configs from error to warn level so they do not block CRA compilation.

BREAKING CHANGE: PRETTIER flag was replaced with CODE_STYLE.